### PR TITLE
Single request to retrieve entity's data + use of Wiki FR name

### DIFF
--- a/src/recordsnbawiki/packLogic/Controller.java
+++ b/src/recordsnbawiki/packLogic/Controller.java
@@ -4,8 +4,7 @@ import recordsnbawiki.packLogic.json.JsonManagement;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import java.util.Map;
 import recordsnbawiki.packLogic.wikidata.Wikidata;
 import recordsnbawiki.packLogic.wikidata.WikidataItem;
 import recordsnbawiki.packVue.Window;
@@ -52,13 +51,12 @@ public class Controller {
         try {
             realGM.setJson(new JsonManagement());
 
-            String realgmId = wikidata.retrieveRealGMId(player.getId());
-            String espnId = wikidata.retrieveESPNId(player.getId());
+            Map<String, String> entity = wikidata.retrieveEntity(player.getId());
 
-            String realgmContent = realGM.genererContenu(realgmId);
-            String espnContent = espn.genererContenu(espnId);
+            String realgmContent = realGM.genererContenu(entity.get("realgmId"));
+            String espnContent = espn.genererContenu(entity.get("espnId"));
 
-            header = new Header(realGM, espn, player.getLabel());
+            header = new Header(realGM, espn, entity.get("name"));
 
             String finalContent;
 


### PR DESCRIPTION
We now send a single request to the Wikidata API to get the RealGM ID and the ESPN ID. We also use this request to retrieve the name of the article from the French Wikipedia in order to use it in the content header instead of the Wikidata label which is sometimes different.